### PR TITLE
Add CLI integration test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,6 +2040,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ arboard = "3.5.0"
 tokio-util = { version = "0.7", features = ["codec"] }
 directories = "6.0.0"
 scopeguard = "1.2.0"
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,0 +1,121 @@
+mod assert_cmd {
+    use std::process::{Command, Output};
+
+    pub trait CommandCargoExt {
+        fn cargo_bin(name: &str) -> Self;
+    }
+
+    impl CommandCargoExt for Command {
+        fn cargo_bin(name: &str) -> Self {
+            let var = format!("CARGO_BIN_EXE_{name}");
+            let path = std::env::var(&var).unwrap_or_else(|_| {
+                let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                p.push("target/debug");
+                p.push(name);
+                p.to_string_lossy().into_owned()
+            });
+            Command::new(path)
+        }
+    }
+
+    pub trait AssertCmd {
+        fn assert(self) -> Assert;
+    }
+
+    pub struct Assert {
+        output: Output,
+    }
+
+    impl Assert {
+        pub fn success(self) -> Self {
+            assert!(self.output.status.success());
+            self
+        }
+
+        pub fn stdout<P: Fn(&str) -> bool>(self, pred: P) -> Self {
+            let out = String::from_utf8_lossy(&self.output.stdout);
+            assert!(pred(&out));
+            self
+        }
+    }
+
+    impl AssertCmd for Command {
+        fn assert(mut self) -> Assert {
+            let output = self.output().expect("run command");
+            Assert { output }
+        }
+    }
+
+    pub mod prelude {
+        pub use super::{AssertCmd, CommandCargoExt};
+    }
+}
+
+mod predicates {
+    pub mod str {
+        pub fn contains<'a>(s: &'a str) -> impl Fn(&str) -> bool + 'a {
+            move |input: &str| input.contains(s)
+        }
+    }
+
+    pub mod prelude {}
+}
+
+use assert_cmd::prelude::*;
+use predicates::str;
+use std::fs;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::thread::sleep;
+use std::time::Duration;
+use tempfile::TempDir;
+use voice_input::ipc::SOCKET_PATH;
+
+fn spawn_daemon(tmp: &TempDir) -> Child {
+    let mut cmd = Command::cargo_bin("voice_inputd");
+    cmd.env("TMPDIR", tmp.path());
+    let mut child = cmd.spawn().expect("spawn daemon");
+    for _ in 0..10 {
+        if Path::new(SOCKET_PATH).exists() {
+            break;
+        }
+        sleep(Duration::from_millis(200));
+    }
+    child
+}
+
+fn kill_daemon(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_file(SOCKET_PATH);
+}
+
+#[test]
+fn list_devices_runs() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = TempDir::new()?;
+    let mut daemon = spawn_daemon(&tmp);
+
+    let mut cmd = Command::cargo_bin("voice_input");
+    cmd.arg("--list-devices").env("TMPDIR", tmp.path());
+    cmd.assert().success().stdout(str::contains(""));
+
+    kill_daemon(&mut daemon);
+    Ok(())
+}
+
+#[test]
+fn toggle_start_stop() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = TempDir::new()?;
+    let mut daemon = spawn_daemon(&tmp);
+
+    let mut start = Command::cargo_bin("voice_input");
+    start.arg("toggle").env("TMPDIR", tmp.path());
+    start.assert().success();
+
+    let mut stop = Command::cargo_bin("voice_input");
+    stop.arg("toggle").env("TMPDIR", tmp.path());
+    stop.assert().success();
+
+    kill_daemon(&mut daemon);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a minimal `tests/cli_integration.rs`
- implement lightweight replacements for `assert_cmd`/`predicates`
- use temporary directory via `tempfile`
- exercise `--list-devices` and `toggle` commands

## Testing
- `cargo check`
- `cargo test -- --test-threads=1`