### PR TITLE
Fix failing tests by using TMPDIR socket

### DIFF
--- a/src/bin/voice_inputd.rs
+++ b/src/bin/voice_inputd.rs
@@ -40,7 +40,7 @@ use voice_input::{
             sound::{pause_apple_music, play_start_sound, play_stop_sound, resume_apple_music},
         },
     },
-    ipc::{IpcCmd, IpcResp, SOCKET_PATH},
+    ipc::{IpcCmd, IpcResp, socket_path},
     load_env,
 };
 
@@ -87,9 +87,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 /// ソケット待受・クライアントハンドリング・転写ワーカーを起動する本体。
 async fn async_main() -> Result<(), Box<dyn Error>> {
     // 既存ソケットがあれば削除して再バインド
-    let _ = fs::remove_file(SOCKET_PATH);
-    let listener = UnixListener::bind(SOCKET_PATH)?;
-    println!("voice-inputd listening on {SOCKET_PATH}");
+    let path = socket_path();
+    let _ = fs::remove_file(&path);
+    let listener = UnixListener::bind(&path)?;
+    println!("voice-inputd listening on {:?}", path);
 
     let recorder = Arc::new(Recorder::new(CpalAudioBackend::default()));
     let ctx = Arc::new(Mutex::new(RecCtx {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,10 +1,16 @@
 //! Unix Domain Socket (UDS) ベースのシンプルな IPC モジュール。
 //! `voice_input` CLI ↔ `voice_inputd` デーモン間の通信で利用します。
 use serde::{Deserialize, Serialize};
-use std::{error::Error, path::Path};
+use std::{
+    error::Error,
+    path::{Path, PathBuf},
+};
 
-/// デーモンソケットパス
-pub const SOCKET_PATH: &str = "/tmp/voice_input.sock";
+/// デーモンソケットパスを返します。
+pub fn socket_path() -> PathBuf {
+    let dir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(dir).join("voice_input.sock")
+}
 
 /// CLI からデーモンへ送るコマンド列挙。
 #[derive(Debug, Serialize, Deserialize)]
@@ -43,11 +49,12 @@ pub fn send_cmd(cmd: &IpcCmd) -> Result<IpcResp, Box<dyn Error>> {
         .enable_all()
         .build()?
         .block_on(async {
-            if !Path::new(SOCKET_PATH).exists() {
+            let path = socket_path();
+            if !Path::new(&path).exists() {
                 return Err("daemon socket not found".into());
             }
 
-            let stream = UnixStream::connect(SOCKET_PATH).await?;
+            let stream = UnixStream::connect(path).await?;
             let (r, w) = stream.into_split();
             let mut writer = FramedWrite::new(w, LinesCodec::new());
             let mut reader = FramedRead::new(r, LinesCodec::new());

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -69,14 +69,14 @@ use std::process::{Child, Command};
 use std::thread::sleep;
 use std::time::Duration;
 use tempfile::TempDir;
-use voice_input::ipc::SOCKET_PATH;
+use voice_input::ipc::socket_path;
 
 fn spawn_daemon(tmp: &TempDir) -> Child {
     let mut cmd = Command::cargo_bin("voice_inputd");
     cmd.env("TMPDIR", tmp.path());
-    let mut child = cmd.spawn().expect("spawn daemon");
+    let child = cmd.spawn().expect("spawn daemon");
     for _ in 0..10 {
-        if Path::new(SOCKET_PATH).exists() {
+        if Path::new(&socket_path()).exists() {
             break;
         }
         sleep(Duration::from_millis(200));
@@ -87,7 +87,7 @@ fn spawn_daemon(tmp: &TempDir) -> Child {
 fn kill_daemon(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
-    let _ = fs::remove_file(SOCKET_PATH);
+    let _ = fs::remove_file(socket_path());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow IPC socket path to vary by TMPDIR
- update daemon and tests to use new helper

## Testing
- `cargo check`
- `cargo test`
