### PR TITLE
Add tests for JsonFileDictRepo

### DIFF
--- a/src/infrastructure/dict/json_repo.rs
+++ b/src/infrastructure/dict/json_repo.rs
@@ -40,3 +40,80 @@ impl DictRepository for JsonFileDictRepo {
         Ok(())
     }
 }
+
+// === Unit tests ==========================================================
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn repo_in_tmp() -> (JsonFileDictRepo, TempDir) {
+        let tmp = TempDir::new().expect("create tempdir");
+        let repo = JsonFileDictRepo {
+            path: tmp.path().join("dictionary.json"),
+        };
+        (repo, tmp)
+    }
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let (repo, _tmp) = repo_in_tmp();
+        let entries = repo.load().expect("load");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let (repo, _tmp) = repo_in_tmp();
+        let list = vec![WordEntry {
+            surface: "foo".into(),
+            replacement: "bar".into(),
+            hit: 1,
+        }];
+        repo.save(&list).expect("save");
+        let loaded = repo.load().expect("load");
+        assert_eq!(loaded.len(), list.len());
+        assert_eq!(loaded[0].surface, list[0].surface);
+        assert_eq!(loaded[0].replacement, list[0].replacement);
+        assert_eq!(loaded[0].hit, list[0].hit);
+    }
+
+    #[test]
+    fn upsert_adds_and_updates() {
+        let (repo, _tmp) = repo_in_tmp();
+        repo.upsert(WordEntry {
+            surface: "foo".into(),
+            replacement: "bar".into(),
+            hit: 0,
+        })
+        .expect("upsert add");
+
+        repo.upsert(WordEntry {
+            surface: "foo".into(),
+            replacement: "baz".into(),
+            hit: 2,
+        })
+        .expect("upsert update");
+
+        let loaded = repo.load().expect("load");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].surface, "foo");
+        assert_eq!(loaded[0].replacement, "baz");
+        assert_eq!(loaded[0].hit, 2);
+    }
+
+    #[test]
+    fn delete_removes_entry() {
+        let (repo, _tmp) = repo_in_tmp();
+        repo.upsert(WordEntry {
+            surface: "foo".into(),
+            replacement: "bar".into(),
+            hit: 0,
+        })
+        .expect("upsert");
+        assert!(repo.delete("foo").expect("delete existing"));
+        assert!(!repo.delete("foo").expect("delete missing"));
+        let loaded = repo.load().expect("load");
+        assert!(loaded.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- cover JSON dictionary repo with unit tests using `tempfile`

## Testing
- `cargo check`
- `cargo test`
