### PR TITLE
Add configurable dictionary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ voice_input health
 辞書は JSON 形式で `~/Library/Application Support/voice_input/dictionary.json` に保存され、
 CLI から編集できます。
 
+保存先を変更したい場合は次のコマンドを実行してください。設定は同ディレクトリの
+`config.json` に記録され、変更時には旧ファイルが `<旧パス>.bak` として残ります。
+
+```sh
+voice_input config set dict-path /path/to/shared/dictionary.json
+```
+
 ```sh
 # 単語登録または更新
 voice_input dict add "誤変換" "正しい語"

--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -1,0 +1,82 @@
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::{fs, io, path::PathBuf};
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AppConfig {
+    pub dict_path: Option<String>,
+}
+
+fn data_dir() -> PathBuf {
+    let proj =
+        ProjectDirs::from("com", "user", "voice_input").expect("cannot resolve platform dirs");
+    let dir = proj.data_local_dir();
+    fs::create_dir_all(dir).expect("create data dir");
+    dir.to_path_buf()
+}
+
+fn config_path() -> PathBuf {
+    data_dir().join("config.json")
+}
+
+pub fn default_dict_path() -> PathBuf {
+    data_dir().join("dictionary.json")
+}
+
+impl AppConfig {
+    pub fn load() -> Self {
+        let path = config_path();
+        if let Ok(f) = fs::File::open(&path) {
+            if let Ok(cfg) = serde_json::from_reader(f) {
+                return cfg;
+            }
+        }
+        AppConfig::default()
+    }
+
+    pub fn save(&self) -> io::Result<()> {
+        let path = config_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        {
+            let f = fs::File::create(&tmp)?;
+            serde_json::to_writer_pretty(&f, self)?;
+        }
+        fs::rename(tmp, path)?;
+        Ok(())
+    }
+
+    pub fn dict_path(&self) -> PathBuf {
+        if let Some(p) = &self.dict_path {
+            PathBuf::from(p)
+        } else {
+            default_dict_path()
+        }
+    }
+
+    pub fn set_dict_path(&mut self, new_path: PathBuf) -> io::Result<()> {
+        let old = self.dict_path();
+        if old != new_path {
+            if old.exists() && !new_path.exists() {
+                if let Some(parent) = new_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let bak = old.with_extension("bak");
+                if bak.exists() {
+                    fs::remove_file(&bak)?;
+                }
+                fs::rename(&old, &bak)?;
+                fs::copy(&bak, &new_path)?;
+            } else if !new_path.exists() {
+                if let Some(parent) = new_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+            }
+            self.dict_path = Some(new_path.to_string_lossy().to_string());
+            self.save()?;
+        }
+        Ok(())
+    }
+}

--- a/src/infrastructure/dict/json_repo.rs
+++ b/src/infrastructure/dict/json_repo.rs
@@ -1,6 +1,6 @@
 //! JSON ファイル版 DictRepository 実装
 use crate::domain::dict::{DictRepository, WordEntry};
-use directories::ProjectDirs;
+use crate::infrastructure::config::AppConfig;
 use serde_json::{from_reader, to_writer_pretty};
 use std::{fs, io::Result, path::PathBuf};
 
@@ -10,14 +10,12 @@ pub struct JsonFileDictRepo {
 
 impl JsonFileDictRepo {
     pub fn new() -> Self {
-        // ~/Library/Application Support/voice_input/dictionary.json
-        let proj =
-            ProjectDirs::from("com", "user", "voice_input").expect("cannot resolve platform dirs");
-        let dir = proj.data_local_dir();
-        fs::create_dir_all(dir).expect("create data dir");
-        Self {
-            path: dir.join("dictionary.json"),
+        let cfg = AppConfig::load();
+        let path = cfg.dict_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create data dir");
         }
+        Self { path }
     }
 }
 

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
 pub mod audio;
 pub mod dict;
 pub mod external;
+pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,9 @@
 use clap::{Parser, Subcommand};
 use voice_input::{
     domain::dict::{DictRepository, WordEntry},
+    infrastructure::config::AppConfig,
     infrastructure::dict::JsonFileDictRepo,
-    ipc::{IpcCmd, send_cmd},
+    ipc::{send_cmd, IpcCmd},
     load_env,
 };
 
@@ -48,6 +49,11 @@ enum Cmd {
         #[command(subcommand)]
         action: DictCmd,
     },
+    /// 各種設定操作
+    Config {
+        #[command(subcommand)]
+        action: ConfigCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -61,6 +67,22 @@ enum DictCmd {
     Remove { surface: String },
     /// 一覧表示
     List,
+}
+
+#[derive(Subcommand)]
+enum ConfigCmd {
+    /// `dict-path` 設定
+    Set {
+        #[command(subcommand)]
+        field: ConfigField,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigField {
+    /// 辞書ファイルの保存先を指定
+    #[command(name = "dict-path")]
+    DictPath { path: String },
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -125,6 +147,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
+        Cmd::Config { action } => match action {
+            ConfigCmd::Set { field } => match field {
+                ConfigField::DictPath { path } => {
+                    let mut cfg = AppConfig::load();
+                    cfg.set_dict_path(std::path::PathBuf::from(&path))?;
+                    println!("✅ dict-path set to {path}");
+                }
+            },
+        },
     }
     Ok(())
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -167,3 +167,31 @@ fn dict_add_list_remove() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn config_set_moves_dict() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = TempDir::new()?;
+
+    let data_home = tmp.path();
+    let default_dict = data_home.join("voice_input/dictionary.json");
+    let new_path = data_home.join("shared/dict.json");
+
+    // create dictionary at default location
+    let mut add = Command::cargo_bin("voice_input");
+    add.args(["dict", "add", "foo", "bar"])
+        .env("XDG_DATA_HOME", data_home);
+    add.assert().success();
+
+    assert!(default_dict.exists());
+
+    // change path
+    let mut set = Command::cargo_bin("voice_input");
+    set.args(["config", "set", "dict-path", new_path.to_str().unwrap()])
+        .env("XDG_DATA_HOME", data_home);
+    set.assert().success();
+
+    assert!(new_path.exists());
+    assert!(default_dict.with_extension("bak").exists());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `AppConfig` for storing settings like dictionary path
- load and set dictionary path via config file with backup when moved
- extend CLI with `config set dict-path` command
- document config usage in README
- test path migration

## Testing
- `cargo check`
- `cargo test`