### PR TITLE
Add status field to dictionary entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/main.rs"
 name = "voice_inputd"            # 常駐デーモン
 path = "src/bin/voice_inputd.rs"
 
+[[bin]]
+name = "migrate_dict"           # 辞書マイグレーション
+path = "src/bin/migrate_dict.rs"
+
 # ─────────────────────────────────────────
 # 依存クレート ― ご指定をそのまま使用
 # ─────────────────────────────────────────

--- a/src/bin/migrate_dict.rs
+++ b/src/bin/migrate_dict.rs
@@ -1,0 +1,9 @@
+use voice_input::{domain::dict::DictRepository, infrastructure::dict::JsonFileDictRepo};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let repo = JsonFileDictRepo::new();
+    let list = repo.load()?;
+    repo.save(&list)?; // save again to write new status field
+    println!("✅ dictionary migrated ({} entries)", list.len());
+    Ok(())
+}

--- a/src/infrastructure/dict/json_repo.rs
+++ b/src/infrastructure/dict/json_repo.rs
@@ -1,4 +1,6 @@
 //! JSON ファイル版 DictRepository 実装
+#[cfg(test)]
+use crate::domain::dict::EntryStatus;
 use crate::domain::dict::{DictRepository, WordEntry};
 use directories::ProjectDirs;
 use serde_json::{from_reader, to_writer_pretty};
@@ -69,6 +71,7 @@ mod tests {
             surface: "foo".into(),
             replacement: "bar".into(),
             hit: 1,
+            status: EntryStatus::Active,
         }];
         repo.save(&list).expect("save");
         let loaded = repo.load().expect("load");
@@ -85,6 +88,7 @@ mod tests {
             surface: "foo".into(),
             replacement: "bar".into(),
             hit: 0,
+            status: EntryStatus::Active,
         })
         .expect("upsert add");
 
@@ -92,6 +96,7 @@ mod tests {
             surface: "foo".into(),
             replacement: "baz".into(),
             hit: 2,
+            status: EntryStatus::Active,
         })
         .expect("upsert update");
 
@@ -109,6 +114,7 @@ mod tests {
             surface: "foo".into(),
             replacement: "bar".into(),
             hit: 0,
+            status: EntryStatus::Active,
         })
         .expect("upsert");
         assert!(repo.delete("foo").expect("delete existing"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@
 //! `Start` / `Stop` / `Toggle` / `Status` の各コマンドを `ipc::send_cmd` で送信します。
 use clap::{Parser, Subcommand};
 use voice_input::{
-    domain::dict::{DictRepository, WordEntry},
+    domain::dict::{DictRepository, EntryStatus, WordEntry},
     infrastructure::dict::JsonFileDictRepo,
-    ipc::{IpcCmd, send_cmd},
+    ipc::{send_cmd, IpcCmd},
     load_env,
 };
 
@@ -102,6 +102,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         surface: surface.clone(),
                         replacement,
                         hit: 0,
+                        status: EntryStatus::Active,
                     })?;
                     println!("✅ Added/updated entry for “{surface}”");
                 }
@@ -119,7 +120,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     } else {
                         println!("─ Dictionary ───────────────");
                         for e in list {
-                            println!("• {:<20} → {}", e.surface, e.replacement);
+                            println!("• {:<20} → {} [{}]", e.surface, e.replacement, e.status);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- extend `WordEntry` with `status` field and add `EntryStatus` enum
- use status when applying replacements and when listing entries
- update CLI to add entries as active and show status in listings
- update JSON repo tests and add migration utility

## Testing
- `cargo check`
- `cargo test`