### PR TITLE
Add OpenAI dict suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ OPENAI_API_KEY=your_openai_api_key_here
 # OpenAI Transcription Model (default: gpt-4o-mini-transcribe)
 # Other options: gpt-4o-transcribe, whisper-1
 OPENAI_TRANSCRIBE_MODEL=gpt-4o-mini-transcribe
+# Model used for dictionary suggestions (default: gpt-4o)
+OPENAI_DICT_MODEL=gpt-4o
 # Input device priority (comma-separated list of device names)
 # The first device in the list has the highest priority.
 INPUT_DEVICE_PRIORITY="device1,device2,device3"


### PR DESCRIPTION
## Summary
- implement dictionary suggestions from ChatGPT
- use suggestions in the daemon after transcription and save as draft entries
- document OPENAI_DICT_MODEL in `.env.example`

## Testing
- `cargo check`
- `cargo test`
