### PR TITLE
Simplify audio backend API

### DIFF
--- a/src/bin/voice_inputd.rs
+++ b/src/bin/voice_inputd.rs
@@ -264,9 +264,9 @@ async fn start_recording(
         tokio::select! {
             _ = tokio::time::sleep(Duration::from_secs(max_secs)) => {
                 if recorder.borrow().is_recording() {
-                    if let Ok(audio_data) = recorder.borrow_mut().stop_raw() {
+                    if let Ok(bytes) = recorder.borrow_mut().stop_raw() {
                         let result = RecordingResult {
-                            audio_data: audio_data.into(),
+                            audio_data: AudioDataDto::Memory(bytes),
                             duration_ms: 0, // Duration tracking not implemented yet
                         };
 
@@ -333,7 +333,7 @@ async fn stop_recording(
     }
 
     play_stop_sound();
-    let audio_data = recorder.borrow_mut().stop_raw()?;
+    let bytes = recorder.borrow_mut().stop_raw()?;
     c.state = RecState::Idle;
 
     // 開始時の保存値→引数→現在の選択の順でプロンプトを決定
@@ -341,7 +341,7 @@ async fn stop_recording(
     let final_prompt = prompt.or(stored).or_else(|| get_selected_text().ok());
 
     let result = RecordingResult {
-        audio_data: audio_data.into(),
+        audio_data: AudioDataDto::Memory(bytes),
         duration_ms: 0, // Duration tracking not implemented yet
     };
 

--- a/src/bin/voice_inputd.rs
+++ b/src/bin/voice_inputd.rs
@@ -35,7 +35,7 @@ use voice_input::{
     domain::dict::{DictRepository, apply_replacements},
     domain::recorder::Recorder,
     infrastructure::{
-        audio::{CpalAudioBackend, cpal_backend::AudioData},
+        audio::CpalAudioBackend,
         dict::JsonFileDictRepo,
         external::{
             clipboard::get_selected_text,
@@ -44,7 +44,7 @@ use voice_input::{
             text_input,
         },
     },
-    ipc::{IpcCmd, IpcResp, RecordingResult, socket_path},
+    ipc::{AudioDataDto, IpcCmd, IpcResp, RecordingResult, socket_path},
     load_env,
 };
 
@@ -378,10 +378,10 @@ async fn handle_transcription(
         }
     };
 
-    // Convert AudioDataDto back to AudioData
-    let audio_data: AudioData = result.audio_data.into();
+    // Convert AudioDataDto to Vec<u8>
+    let wav_data: Vec<u8> = result.audio_data.into();
 
-    let text_result = openai_client.transcribe_audio(audio_data).await;
+    let text_result = openai_client.transcribe_audio(wav_data).await;
 
     // 転写に失敗してもクリップボード操作やペーストは試みない
     match text_result {

--- a/src/domain/recorder.rs
+++ b/src/domain/recorder.rs
@@ -1,4 +1,4 @@
-use crate::infrastructure::audio::{AudioBackend, AudioData};
+use crate::infrastructure::audio::AudioBackend;
 use crate::monitoring::{
     MemoryMonitor,
     metrics::{MetricsCollector, RecordingMode},
@@ -29,21 +29,10 @@ impl<T: AudioBackend> Recorder<T> {
         self
     }
 
-    /// メモリモードかどうかを判定
-    fn is_memory_mode(&self) -> bool {
-        // 環境変数で判定する簡易実装
-        std::env::var("LEGACY_TMP_WAV_FILE").unwrap_or_default() != "true"
-    }
-
     /// 録音を開始します。
     pub fn start(&mut self) -> Result<(), Box<dyn Error>> {
         // メトリクス収集開始
-        let mode = if self.is_memory_mode() {
-            RecordingMode::Memory
-        } else {
-            RecordingMode::File
-        };
-        self.metrics_collector = Some(MetricsCollector::new(mode));
+        self.metrics_collector = Some(MetricsCollector::new(RecordingMode::Memory));
 
         if let Some(ref mut collector) = self.metrics_collector {
             collector.start_recording();
@@ -52,49 +41,27 @@ impl<T: AudioBackend> Recorder<T> {
         self.backend.start_recording()
     }
 
-    /// 録音を停止し、保存された WAV ファイルのパスを返します。
-    /// 注意: このメソッドは廃止予定です。代わりに stop_raw() を使用してください。
-    /// メモリモードでは一時ファイルを作成しません。
-    pub fn stop(&mut self) -> Result<String, Box<dyn Error>> {
-        match self.backend.stop_recording()? {
-            AudioData::File(path) => Ok(path.to_string_lossy().into_owned()),
-            AudioData::Memory(_) => {
-                // メモリモードでは一時ファイルを作成しない
-                Err("Memory mode is not supported by stop(). Use stop_raw() instead.".into())
-            }
-        }
-    }
-
-    /// 録音を停止し、音声データを返します。
-    /// 新しいAPIで、AudioData型を直接返します。
-    pub fn stop_raw(&mut self) -> Result<AudioData, Box<dyn Error>> {
+    /// 録音を停止し、WAV データを返します。
+    pub fn stop_raw(&mut self) -> Result<Vec<u8>, Box<dyn Error>> {
         if let Some(ref mut collector) = self.metrics_collector {
             collector.start_processing();
         }
 
-        let result = self.backend.stop_recording()?;
+        let data = self.backend.stop_recording()?;
 
-        // メモリ使用量の更新
-        if let AudioData::Memory(ref data) = result {
-            if let Some(ref monitor) = self.memory_monitor {
-                monitor.update_usage(data.len());
-            }
+        if let Some(ref monitor) = self.memory_monitor {
+            monitor.update_usage(data.len());
         }
 
         // メトリクスの完了
         if let (Some(collector), Some(monitor)) =
             (self.metrics_collector.take(), &self.memory_monitor)
         {
-            let audio_bytes = match &result {
-                AudioData::Memory(data) => data.len(),
-                AudioData::File(_) => 0, // ファイルモードではサイズ不明
-            };
-
-            let metrics = collector.finish(audio_bytes, monitor.get_metrics());
+            let metrics = collector.finish(data.len(), monitor.get_metrics());
             metrics.log_summary();
         }
 
-        Ok(result)
+        Ok(data)
     }
 
     /// 録音中かどうかを返します。
@@ -112,16 +79,14 @@ mod tests {
     /// テスト用のモックAudioBackend
     struct MockAudioBackend {
         recording: Arc<AtomicBool>,
-        return_memory: bool,
         test_data: Vec<u8>,
     }
 
     impl MockAudioBackend {
-        fn new(return_memory: bool) -> Self {
+        fn new() -> Self {
             Self {
                 recording: Arc::new(AtomicBool::new(false)),
-                return_memory,
-                test_data: vec![1, 2, 3, 4, 5], // テスト用のダミーデータ
+                test_data: vec![1, 2, 3, 4, 5],
             }
         }
     }
@@ -132,13 +97,9 @@ mod tests {
             Ok(())
         }
 
-        fn stop_recording(&self) -> Result<AudioData, Box<dyn Error>> {
+        fn stop_recording(&self) -> Result<Vec<u8>, Box<dyn Error>> {
             self.recording.store(false, Ordering::SeqCst);
-            if self.return_memory {
-                Ok(AudioData::Memory(self.test_data.clone()))
-            } else {
-                Ok(AudioData::File("/tmp/test.wav".into()))
-            }
+            Ok(self.test_data.clone())
         }
 
         fn is_recording(&self) -> bool {
@@ -147,50 +108,13 @@ mod tests {
     }
 
     #[test]
-    fn test_recorder_with_file_backend() {
-        let backend = MockAudioBackend::new(false);
-        let mut recorder = Recorder::new(backend);
-
-        // 録音開始
-        assert!(recorder.start().is_ok());
-        assert!(recorder.is_recording());
-
-        // 録音停止（ファイルモード）
-        let result = recorder.stop().unwrap();
-        assert_eq!(result, "/tmp/test.wav");
-        assert!(!recorder.is_recording());
-    }
-
-    #[test]
-    fn test_recorder_with_memory_backend() {
-        let backend = MockAudioBackend::new(true);
-        let mut recorder = Recorder::new(backend);
-
-        // 録音開始
-        assert!(recorder.start().is_ok());
-        assert!(recorder.is_recording());
-
-        // 録音停止（メモリモード）
-        // Note: stop()メソッドは廃止予定。メモリモードでは一時ファイルを作成しない
-        let result = recorder.stop();
-        assert!(result.is_err() || result.unwrap().is_empty());
-        assert!(!recorder.is_recording());
-    }
-
-    #[test]
     fn test_recorder_stop_raw() {
-        let backend = MockAudioBackend::new(true);
+        let backend = MockAudioBackend::new();
         let mut recorder = Recorder::new(backend);
 
         recorder.start().unwrap();
 
-        // stop_rawは直接AudioDataを返す
-        let result = recorder.stop_raw().unwrap();
-        match result {
-            AudioData::Memory(data) => {
-                assert_eq!(data, vec![1, 2, 3, 4, 5]);
-            }
-            _ => panic!("Expected AudioData::Memory"),
-        }
+        let data = recorder.stop_raw().unwrap();
+        assert_eq!(data, vec![1, 2, 3, 4, 5]);
     }
 }

--- a/src/infrastructure/audio/cpal_backend.rs
+++ b/src/infrastructure/audio/cpal_backend.rs
@@ -648,23 +648,6 @@ mod tests {
         assert_eq!(&result[50..52], &[56u8, 255]); // R: -200
     }
 
-    #[test]
-    fn test_audio_data_enum() {
-        // Memory variant
-        let data = vec![1, 2, 3, 4, 5];
-        let audio_data = AudioData::Memory(data.clone());
-
-        let AudioData::Memory(vec) = &audio_data;
-        assert_eq!(vec, &data);
-
-        // Debug trait
-        assert!(format!("{:?}", audio_data).contains("Memory"));
-
-        // Clone trait
-        let cloned = audio_data.clone();
-        let AudioData::Memory(vec) = cloned;
-        assert_eq!(vec, data);
-    }
 
     #[test]
     fn test_recording_state_creation() {
@@ -745,7 +728,6 @@ mod tests {
         backend.recording.store(true, Ordering::SeqCst);
 
         // stop_recordingを実行
-<<<<<<< HEAD
         let wav_data = backend.stop_recording().unwrap();
 
         // WAVヘッダー（44バイト）+ データ（5サンプル * 2バイト = 10バイト）
@@ -754,41 +736,6 @@ mod tests {
         // WAVヘッダーの基本チェック
         assert_eq!(&wav_data[0..4], b"RIFF");
         assert_eq!(&wav_data[8..12], b"WAVE");
-
-        // 録音状態がクリアされていることを確認
-        assert!(!backend.is_recording());
-        assert!(backend.recording_state.lock().unwrap().is_none());
-    }
-
-    #[test]
-    fn test_stop_recording_file_mode() {
-        // ファイルモードでの動作をシミュレート
-        let backend = CpalAudioBackend::default();
-
-        // テスト用のRecordingState::Fileを設定
-        let test_path = PathBuf::from("/tmp/test.wav");
-        *backend.recording_state.lock().unwrap() = Some(RecordingState::File {
-            path: test_path.clone(),
-        });
-
-        // 録音フラグを設定
-        backend.recording.store(true, Ordering::SeqCst);
-
-        // stop_recordingを実行
-        let wav_data = backend.stop_recording().unwrap();
-        // ファイルモードでもバイト列が返る
-        assert!(!wav_data.is_empty());
-        assert!(test_path.exists());
-=======
-        let result = backend.stop_recording().unwrap();
-        let AudioData::Memory(wav_data) = result;
-        // WAVヘッダー（44バイト）+ データ（5サンプル * 2バイト = 10バイト）
-        assert_eq!(wav_data.len(), 54);
-
-        // WAVヘッダーの基本チェック
-        assert_eq!(&wav_data[0..4], b"RIFF");
-        assert_eq!(&wav_data[8..12], b"WAVE");
->>>>>>> onmemory_wav_after_imp
 
         // 録音状態がクリアされていることを確認
         assert!(!backend.is_recording());
@@ -881,16 +828,9 @@ mod tests {
                 std::thread::sleep(std::time::Duration::from_millis(100));
 
                 // 録音停止
-<<<<<<< HEAD
                 let data = backend.stop_recording().unwrap();
                 println!("録音データサイズ: {} bytes", data.len());
                 assert!(data.len() > 44);
-=======
-                let result = backend.stop_recording().unwrap();
-                let AudioData::Memory(data) = result;
-                println!("録音データサイズ: {} bytes", data.len());
-                assert!(data.len() > 44); // 少なくともWAVヘッダーより大きい
->>>>>>> onmemory_wav_after_imp
             }
             Err(e) => {
                 println!("録音開始失敗（デバイスなし）: {}", e);

--- a/src/infrastructure/audio/mod.rs
+++ b/src/infrastructure/audio/mod.rs
@@ -9,10 +9,8 @@ pub trait AudioBackend {
     /// 録音を開始。
     fn start_recording(&self) -> Result<(), Box<dyn Error>>;
 
-    /// 録音を停止し、音声データを返します。
-    /// メモリモードの場合はWAVフォーマットのバイトデータ、
-    /// レガシーモードの場合はWAVファイルのパスを返します。
-    fn stop_recording(&self) -> Result<AudioData, Box<dyn Error>>;
+    /// 録音を停止し、WAV フォーマットのバイトデータを返します。
+    fn stop_recording(&self) -> Result<Vec<u8>, Box<dyn Error>>;
 
     /// 現在録音中であれば `true`。
     fn is_recording(&self) -> bool;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -55,20 +55,16 @@ pub struct RecordingResult {
     pub duration_ms: u64,
 }
 
-use crate::infrastructure::audio::cpal_backend::AudioData;
-
-impl From<AudioData> for AudioDataDto {
-    fn from(data: AudioData) -> Self {
-        match data {
-            AudioData::Memory(bytes) => AudioDataDto::Memory(bytes),
-        }
+impl From<Vec<u8>> for AudioDataDto {
+    fn from(bytes: Vec<u8>) -> Self {
+        AudioDataDto::Memory(bytes)
     }
 }
 
-impl From<AudioDataDto> for AudioData {
+impl From<AudioDataDto> for Vec<u8> {
     fn from(dto: AudioDataDto) -> Self {
         match dto {
-            AudioDataDto::Memory(bytes) => AudioData::Memory(bytes),
+            AudioDataDto::Memory(bytes) => bytes,
         }
     }
 }
@@ -156,21 +152,20 @@ mod tests {
     }
 
     #[test]
-    fn test_from_audio_data_to_dto() {
-        // Test Memory variant
-        let audio_data = AudioData::Memory(vec![1, 2, 3, 4]);
-        let dto: AudioDataDto = audio_data.into();
+    fn test_from_vec_to_dto() {
+        // Test Vec<u8> to AudioDataDto conversion
+        let wav_data = vec![1, 2, 3, 4];
+        let dto: AudioDataDto = wav_data.clone().into();
         let AudioDataDto::Memory(data) = dto;
-        assert_eq!(data, vec![1, 2, 3, 4]);
+        assert_eq!(data, wav_data);
     }
 
     #[test]
-    fn test_from_dto_to_audio_data() {
-        // Test Memory variant
+    fn test_from_dto_to_vec() {
+        // Test AudioDataDto to Vec<u8> conversion
         let dto = AudioDataDto::Memory(vec![5, 6, 7, 8]);
-        let audio_data: AudioData = dto.into();
-        let AudioData::Memory(data) = audio_data;
-        assert_eq!(data, vec![5, 6, 7, 8]);
+        let wav_data: Vec<u8> = dto.into();
+        assert_eq!(wav_data, vec![5, 6, 7, 8]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- change AudioBackend::stop_recording to return raw bytes
- update CPAL backend to always provide `Vec<u8>`
- drop memory mode checks and deprecated stop() from `Recorder`
- adjust voice_inputd, benches and tests for new API

## Testing
- `cargo check`
- `cargo clippy --all-targets --features ci-test -- -D warnings`
- `cargo test --features ci-test` *(fails: linking with `cc` failed)*