### PR TITLE
Refactor IPC audio data handling

### DIFF
--- a/src/bin/voice_inputd.rs
+++ b/src/bin/voice_inputd.rs
@@ -23,7 +23,7 @@ use std::{
 
 use arboard::Clipboard;
 use futures::{SinkExt, StreamExt};
-use serde_json::{Value, json};
+
 use tokio::{
     net::{UnixListener, UnixStream},
     sync::{Semaphore, mpsc, oneshot},
@@ -44,7 +44,7 @@ use voice_input::{
             text_input,
         },
     },
-    ipc::{AudioDataDto, IpcCmd, IpcResp, RecordingResult, socket_path},
+    ipc::{IpcCmd, IpcResp, RecordingResult, socket_path},
     load_env,
 };
 
@@ -270,7 +270,7 @@ async fn start_recording(
                             duration_ms: 0, // Duration tracking not implemented yet
                         };
 
-                        let (was_playing, stored_paste, stored_direct_input, prompt_to_save) = {
+                        let (was_playing, stored_paste, stored_direct_input) = {
                             let mut c = match ctx_clone.lock() {
                                 Ok(g) => g,
                                 Err(e) => {
@@ -280,20 +280,10 @@ async fn start_recording(
                             };
                             c.state = RecState::Idle;
                             c.cancel = None;
-                            let stored = c.start_prompt.take();
-                            let prompt = stored.or_else(|| get_selected_text().ok());
                             let w = c.music_was_playing;
                             c.music_was_playing = false;
-                            (w, c.paste, c.direct_input, prompt)
+                            (w, c.paste, c.direct_input)
                         };
-
-                        // Save prompt metadata if using file mode
-                        if let AudioDataDto::File(ref path) = result.audio_data {
-                            if let Some(p) = prompt_to_save {
-                                let meta = format!("{}.json", path);
-                                let _ = fs::write(&meta, json!({ "prompt": p }).to_string());
-                            }
-                        }
 
                         let _ = tx_clone.send((result, stored_paste, was_playing, stored_direct_input));
                         play_stop_sound();
@@ -336,22 +326,15 @@ async fn stop_recording(
     let audio_data = recorder.borrow_mut().stop_raw()?;
     c.state = RecState::Idle;
 
-    // 開始時の保存値→引数→現在の選択の順でプロンプトを決定
-    let stored = c.start_prompt.take();
-    let final_prompt = prompt.or(stored).or_else(|| get_selected_text().ok());
+    // プロンプトは取得するが現在は利用しない
+    let _ = prompt
+        .or(c.start_prompt.take())
+        .or_else(|| get_selected_text().ok());
 
     let result = RecordingResult {
         audio_data: audio_data.into(),
         duration_ms: 0, // Duration tracking not implemented yet
     };
-
-    // Save prompt metadata if using file mode
-    if let AudioDataDto::File(ref path) = result.audio_data {
-        if let Some(p) = final_prompt {
-            let meta = format!("{}.json", path);
-            fs::write(&meta, json!({ "prompt": p }).to_string())?;
-        }
-    }
 
     let was_playing = c.music_was_playing;
     c.music_was_playing = false;
@@ -391,22 +374,6 @@ async fn handle_transcription(
             return Err(e.into());
         }
     };
-
-    // メタJSONが存在すれば prompt を読み込む (file mode only)
-    // Note: The new OpenAI client doesn't support prompt in transcribe_audio yet
-    let _prompt = if let AudioDataDto::File(ref path) = result.audio_data {
-        fs::read_to_string(format!("{}.json", path))
-            .ok()
-            .and_then(|s| {
-                serde_json::from_str::<Value>(&s).ok().and_then(|v| {
-                    v.get("prompt")
-                        .and_then(|p| p.as_str().map(|s| s.to_string()))
-                })
-            })
-    } else {
-        None
-    };
-    let _ = _prompt; // Explicit acknowledgment of unused variable
 
     // Convert AudioDataDto back to AudioData
     let audio_data: AudioData = result.audio_data.into();
@@ -556,51 +523,6 @@ mod tests {
 
     /// `stop_recording` に `prompt` を提供すると、WAV と並べてメタJSONファイルが
     /// 作成されることを検証します。入力デバイスが存在しない場合は自動的にスキップします。
-    #[tokio::test(flavor = "current_thread")]
-    #[ignore = "Requires LocalSet context and audio device"]
-    async fn prompt_is_saved_as_meta() -> Result<(), Box<dyn std::error::Error>> {
-        // このテスト中に30秒タイマーが発火するのを防止する
-        unsafe {
-            std::env::set_var("VOICE_INPUT_MAX_SECS", "60");
-        }
-
-        let recorder = make_recorder();
-        let ctx = Arc::new(Mutex::new(RecCtx {
-            state: RecState::Idle,
-            cancel: None,
-            music_was_playing: false,
-            start_prompt: None,
-            paste: false,
-            direct_input: false,
-        }));
-        let (tx, mut rx) = mpsc::unbounded_channel::<(RecordingResult, bool, bool, bool)>();
-
-        if start_recording(
-            recorder.clone(),
-            &ctx,
-            &tx,
-            false,
-            Some("hello".into()),
-            false,
-        )
-        .await
-        .is_err()
-        {
-            eprintln!("⚠️  No audio device – prompt meta test skipped");
-            return Ok(());
-        }
-        stop_recording(recorder, &ctx, &tx, false, None, false).await?;
-
-        let (result, _, _, _) = rx.recv().await.expect("result not queued");
-        if let AudioDataDto::File(path) = result.audio_data {
-            let meta = std::fs::read_to_string(format!("{}.json", path))?;
-            assert!(meta.contains("hello"));
-        } else {
-            panic!("Expected file mode");
-        }
-        Ok(())
-    }
-
     /// 自動タイムアウト（1秒に設定）が録音を停止し、状態を
     /// Idleに戻すことを確認します。オーディオデバイスが利用できない場合はスキップします。
     #[tokio::test(flavor = "current_thread")]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -46,7 +46,6 @@ pub struct IpcResp {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum AudioDataDto {
     Memory(Vec<u8>),
-    File(String),
 }
 
 /// 録音結果を表す構造体
@@ -62,7 +61,13 @@ impl From<AudioData> for AudioDataDto {
     fn from(data: AudioData) -> Self {
         match data {
             AudioData::Memory(bytes) => AudioDataDto::Memory(bytes),
-            AudioData::File(path) => AudioDataDto::File(path.to_string_lossy().to_string()),
+            AudioData::File(path) => match std::fs::read(&path) {
+                Ok(bytes) => AudioDataDto::Memory(bytes),
+                Err(e) => {
+                    eprintln!("failed to read audio file {path:?}: {e}");
+                    AudioDataDto::Memory(Vec::new())
+                }
+            },
         }
     }
 }
@@ -71,7 +76,6 @@ impl From<AudioDataDto> for AudioData {
     fn from(dto: AudioDataDto) -> Self {
         match dto {
             AudioDataDto::Memory(bytes) => AudioData::Memory(bytes),
-            AudioDataDto::File(path) => AudioData::File(PathBuf::from(path)),
         }
     }
 }
@@ -114,21 +118,8 @@ mod tests {
         let wav_data = vec![0u8, 1, 2, 3, 4, 5];
         let audio_data = AudioDataDto::Memory(wav_data.clone());
 
-        match audio_data {
-            AudioDataDto::Memory(data) => assert_eq!(data, wav_data),
-            _ => panic!("Expected Memory variant"),
-        }
-    }
-
-    #[test]
-    fn test_audio_data_dto_file_variant() {
-        let file_path = "/tmp/test.wav".to_string();
-        let audio_data = AudioDataDto::File(file_path.clone());
-
-        match audio_data {
-            AudioDataDto::File(path) => assert_eq!(path, file_path),
-            _ => panic!("Expected File variant"),
-        }
+        let AudioDataDto::Memory(data) = audio_data;
+        assert_eq!(data, wav_data);
     }
 
     #[test]
@@ -142,27 +133,8 @@ mod tests {
         };
 
         assert_eq!(result.duration_ms, 1500);
-        match result.audio_data {
-            AudioDataDto::Memory(data) => assert_eq!(data, vec![1, 2, 3]),
-            _ => panic!("Expected Memory variant"),
-        }
-    }
-
-    #[test]
-    fn test_recording_result_with_file() {
-        let audio_data = AudioDataDto::File("/tmp/recording.wav".to_string());
-        let duration_ms = 3000u64;
-
-        let result = RecordingResult {
-            audio_data,
-            duration_ms,
-        };
-
-        assert_eq!(result.duration_ms, 3000);
-        match &result.audio_data {
-            AudioDataDto::File(path) => assert_eq!(path, "/tmp/recording.wav"),
-            _ => panic!("Expected File variant"),
-        }
+        let AudioDataDto::Memory(data) = result.audio_data;
+        assert_eq!(data, vec![1, 2, 3]);
     }
 
     #[test]
@@ -171,19 +143,8 @@ mod tests {
         let json = serde_json::to_string(&memory_data).unwrap();
         let deserialized: AudioDataDto = serde_json::from_str(&json).unwrap();
 
-        match deserialized {
-            AudioDataDto::Memory(data) => assert_eq!(data, vec![1, 2, 3, 4, 5]),
-            _ => panic!("Expected Memory variant"),
-        }
-
-        let file_data = AudioDataDto::File("/path/to/file.wav".to_string());
-        let json = serde_json::to_string(&file_data).unwrap();
-        let deserialized: AudioDataDto = serde_json::from_str(&json).unwrap();
-
-        match deserialized {
-            AudioDataDto::File(path) => assert_eq!(path, "/path/to/file.wav"),
-            _ => panic!("Expected File variant"),
-        }
+        let AudioDataDto::Memory(data) = deserialized;
+        assert_eq!(data, vec![1, 2, 3, 4, 5]);
     }
 
     #[test]
@@ -197,51 +158,28 @@ mod tests {
         let deserialized: RecordingResult = serde_json::from_str(&json).unwrap();
 
         assert_eq!(deserialized.duration_ms, 2500);
-        match deserialized.audio_data {
-            AudioDataDto::Memory(data) => assert_eq!(data, vec![10, 20, 30]),
-            _ => panic!("Expected Memory variant"),
-        }
+        let AudioDataDto::Memory(data) = deserialized.audio_data;
+        assert_eq!(data, vec![10, 20, 30]);
     }
 
     #[test]
     fn test_from_audio_data_to_dto() {
-        use std::path::PathBuf;
-
         // Test Memory variant
         let audio_data = AudioData::Memory(vec![1, 2, 3, 4]);
         let dto: AudioDataDto = audio_data.into();
-        match dto {
-            AudioDataDto::Memory(data) => assert_eq!(data, vec![1, 2, 3, 4]),
-            _ => panic!("Expected Memory variant"),
-        }
-
-        // Test File variant
-        let audio_data = AudioData::File(PathBuf::from("/tmp/test.wav"));
-        let dto: AudioDataDto = audio_data.into();
-        match dto {
-            AudioDataDto::File(path) => assert_eq!(path, "/tmp/test.wav"),
-            _ => panic!("Expected File variant"),
-        }
+        let AudioDataDto::Memory(data) = dto;
+        assert_eq!(data, vec![1, 2, 3, 4]);
     }
 
     #[test]
     fn test_from_dto_to_audio_data() {
-        use std::path::PathBuf;
-
         // Test Memory variant
         let dto = AudioDataDto::Memory(vec![5, 6, 7, 8]);
         let audio_data: AudioData = dto.into();
-        match audio_data {
-            AudioData::Memory(data) => assert_eq!(data, vec![5, 6, 7, 8]),
-            _ => panic!("Expected Memory variant"),
-        }
-
-        // Test File variant
-        let dto = AudioDataDto::File("/tmp/output.wav".to_string());
-        let audio_data: AudioData = dto.into();
-        match audio_data {
-            AudioData::File(path) => assert_eq!(path, PathBuf::from("/tmp/output.wav")),
-            _ => panic!("Expected File variant"),
+        if let AudioData::Memory(data) = audio_data {
+            assert_eq!(data, vec![5, 6, 7, 8]);
+        } else {
+            panic!("Expected Memory variant");
         }
     }
 


### PR DESCRIPTION
## Summary
- simplify `AudioDataDto` to only store in-memory data
- remove WAV metadata usage in the daemon
- adjust start/stop recording paths for memory data only
- update tests

## Testing
- `cargo check`
- `cargo clippy --all-targets --features ci-test -- -D warnings`
- `cargo test --features ci-test --color never` *(fails: cannot find -lxdo)*