### PR TITLE
Remove legacy file mode

### DIFF
--- a/src/infrastructure/audio/cpal_backend.rs
+++ b/src/infrastructure/audio/cpal_backend.rs
@@ -3,25 +3,21 @@ use cpal::{
     Device, SampleFormat, Stream, StreamConfig,
     traits::{DeviceTrait, HostTrait, StreamTrait},
 };
-use hound::{SampleFormat as WavFmt, WavWriter};
+
 use std::{
     error::Error,
     fmt,
-    path::PathBuf,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 /// 録音データの返却形式
 #[derive(Debug, Clone)]
 pub enum AudioData {
-    /// WAVフォーマットのバイトデータ（メモリモード）
+    /// WAVフォーマットのバイトデータ
     Memory(Vec<u8>),
-    /// WAVファイルへのパス（レガシーモード）
-    File(PathBuf),
 }
 
 /// 録音状態を管理する内部列挙型
@@ -32,8 +28,6 @@ enum RecordingState {
         sample_rate: u32,
         channels: u16,
     },
-    /// ファイルモード: WAVファイルに直接書き込み
-    File { path: PathBuf },
 }
 
 /// Audio processing errors
@@ -85,8 +79,6 @@ pub struct CpalAudioBackend {
     stream: Mutex<Option<Stream>>,
     /// 録音フラグ
     recording: Arc<AtomicBool>,
-    /// 出力 WAV パス
-    output_path: Mutex<Option<String>>,
     /// 録音状態（メモリモード/ファイルモード）
     recording_state: Mutex<Option<RecordingState>>,
 }
@@ -96,7 +88,6 @@ impl Default for CpalAudioBackend {
         Self {
             stream: Mutex::new(None),
             recording: Arc::new(AtomicBool::new(false)),
-            output_path: Mutex::new(None),
             recording_state: Mutex::new(None),
         }
     }
@@ -248,12 +239,6 @@ impl CpalAudioBackend {
 
 // =============== 内部ユーティリティ ================================
 impl CpalAudioBackend {
-    /// レガシーファイルモードが有効かチェック
-    /// 環境変数 LEGACY_TMP_WAV_FILE が設定されていれば true
-    pub fn is_legacy_mode() -> bool {
-        std::env::var("LEGACY_TMP_WAV_FILE").is_ok()
-    }
-
     /// メモリバッファのサイズ見積もり
     /// 録音時間に基づいて必要なバッファサイズを計算
     fn estimate_buffer_size(duration_secs: u32, sample_rate: u32, channels: u16) -> usize {
@@ -268,17 +253,6 @@ impl CpalAudioBackend {
             .map(|iter| iter.filter_map(|d| d.name().ok()).collect::<Vec<String>>())
             .unwrap_or_default()
     }
-    /// `/tmp/voice_input_<epoch>.wav` 形式の一意なファイルパスを生成
-    fn make_output_path() -> String {
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let mut p = std::env::temp_dir();
-        p.push(format!("voice_input_{ts}.wav"));
-        p.to_string_lossy().into_owned()
-    }
-
     /// メモリモード用のストリーム構築
     fn build_memory_stream(
         recording: Arc<AtomicBool>,
@@ -318,56 +292,6 @@ impl CpalAudioBackend {
 
         Ok(stream)
     }
-
-    /// CPAL ストリームを構築。サンプルを WAV ライターに書き込みます。
-    fn build_input_stream(
-        recording: Arc<AtomicBool>,
-        device: &Device,
-        config: &StreamConfig,
-        sample_format: SampleFormat,
-        output_path: String,
-    ) -> Result<Stream, Box<dyn Error>> {
-        // WAV ヘッダ
-        let spec = hound::WavSpec {
-            channels: config.channels,
-            sample_rate: config.sample_rate.0,
-            bits_per_sample: 16,
-            sample_format: WavFmt::Int,
-        };
-        let writer = Arc::new(Mutex::new(WavWriter::create(&output_path, spec)?));
-
-        let stream = match sample_format {
-            SampleFormat::I16 => device.build_input_stream(
-                config,
-                move |data: &[i16], _| {
-                    if recording.load(Ordering::SeqCst) {
-                        let mut w = writer.lock().unwrap();
-                        for &s in data {
-                            let _ = w.write_sample(s);
-                        }
-                    }
-                },
-                |e| eprintln!("stream error: {e}"),
-                None,
-            )?,
-            SampleFormat::F32 => device.build_input_stream(
-                config,
-                move |data: &[f32], _| {
-                    if recording.load(Ordering::SeqCst) {
-                        let mut w = writer.lock().unwrap();
-                        for &s in data {
-                            let _ = w.write_sample((s * i16::MAX as f32) as i16);
-                        }
-                    }
-                },
-                |e| eprintln!("stream error: {e}"),
-                None,
-            )?,
-            _ => return Err("unsupported sample format".into()),
-        };
-
-        Ok(stream)
-    }
 }
 
 impl AudioBackend for CpalAudioBackend {
@@ -386,49 +310,28 @@ impl AudioBackend for CpalAudioBackend {
         let sample_format = supported.sample_format();
         let config: StreamConfig = supported.into();
 
-        // モード判定とストリーム構築
-        let stream = if Self::is_legacy_mode() {
-            // レガシーモード: ファイルベース
-            let wav_path = Self::make_output_path();
+        // 常にメモリモードでストリームを構築
+        let sample_rate = config.sample_rate.0;
+        let channels = config.channels;
 
-            // RecordingStateをFileモードに設定
-            *self.recording_state.lock().unwrap() = Some(RecordingState::File {
-                path: PathBuf::from(&wav_path),
-            });
+        // 30秒分のバッファを事前確保
+        let capacity = Self::estimate_buffer_size(30, sample_rate, channels);
+        let buffer = Arc::new(Mutex::new(Vec::with_capacity(capacity)));
 
-            *self.output_path.lock().unwrap() = Some(wav_path.clone());
+        // RecordingStateをMemoryモードに設定
+        *self.recording_state.lock().unwrap() = Some(RecordingState::Memory {
+            buffer: buffer.clone(),
+            sample_rate,
+            channels,
+        });
 
-            Self::build_input_stream(
-                self.recording.clone(),
-                &device,
-                &config,
-                sample_format,
-                wav_path,
-            )?
-        } else {
-            // メモリモード: バッファベース
-            let sample_rate = config.sample_rate.0;
-            let channels = config.channels;
-
-            // 30秒分のバッファを事前確保
-            let capacity = Self::estimate_buffer_size(30, sample_rate, channels);
-            let buffer = Arc::new(Mutex::new(Vec::with_capacity(capacity)));
-
-            // RecordingStateをMemoryモードに設定
-            *self.recording_state.lock().unwrap() = Some(RecordingState::Memory {
-                buffer: buffer.clone(),
-                sample_rate,
-                channels,
-            });
-
-            Self::build_memory_stream(
-                self.recording.clone(),
-                &device,
-                &config,
-                sample_format,
-                buffer,
-            )?
-        };
+        let stream = Self::build_memory_stream(
+            self.recording.clone(),
+            &device,
+            &config,
+            sample_format,
+            buffer,
+        )?;
 
         stream.play()?;
         self.recording.store(true, Ordering::SeqCst);
@@ -454,22 +357,15 @@ impl AudioBackend for CpalAudioBackend {
             .take()
             .ok_or("recording state not set")?;
 
-        match state {
-            RecordingState::Memory {
-                buffer,
-                sample_rate,
-                channels,
-            } => {
-                // メモリモード: バッファからWAVデータを生成
-                let samples = buffer.lock().unwrap();
-                let wav_data = Self::combine_wav_data(&samples, sample_rate, channels)?;
-                Ok(AudioData::Memory(wav_data))
-            }
-            RecordingState::File { path, .. } => {
-                // レガシーモード: ファイルパスを返す
-                Ok(AudioData::File(path))
-            }
-        }
+        let RecordingState::Memory {
+            buffer,
+            sample_rate,
+            channels,
+        } = state;
+
+        let samples = buffer.lock().unwrap();
+        let wav_data = Self::combine_wav_data(&samples, sample_rate, channels)?;
+        Ok(AudioData::Memory(wav_data))
     }
 
     /// 録音中かどうかを確認します。
@@ -759,53 +655,21 @@ mod tests {
     }
 
     #[test]
-    fn test_is_legacy_mode() {
-        // 環境変数が設定されていない場合
-        unsafe { std::env::remove_var("LEGACY_TMP_WAV_FILE") };
-        assert!(!CpalAudioBackend::is_legacy_mode());
-
-        // 環境変数が設定されている場合
-        unsafe { std::env::set_var("LEGACY_TMP_WAV_FILE", "1") };
-        assert!(CpalAudioBackend::is_legacy_mode());
-
-        // 空文字列でも有効
-        unsafe { std::env::set_var("LEGACY_TMP_WAV_FILE", "") };
-        assert!(CpalAudioBackend::is_legacy_mode());
-
-        // クリーンアップ
-        unsafe { std::env::remove_var("LEGACY_TMP_WAV_FILE") };
-    }
-
-    #[test]
     fn test_audio_data_enum() {
         // Memory variant
         let data = vec![1, 2, 3, 4, 5];
         let audio_data = AudioData::Memory(data.clone());
 
-        match &audio_data {
-            AudioData::Memory(vec) => assert_eq!(vec, &data),
-            _ => panic!("Expected Memory variant"),
-        }
-
-        // File variant
-        let path = PathBuf::from("/tmp/test.wav");
-        let audio_data_file = AudioData::File(path.clone());
-
-        match &audio_data_file {
-            AudioData::File(p) => assert_eq!(p, &path),
-            _ => panic!("Expected File variant"),
-        }
+        let AudioData::Memory(vec) = &audio_data;
+        assert_eq!(vec, &data);
 
         // Debug trait
         assert!(format!("{:?}", audio_data).contains("Memory"));
-        assert!(format!("{:?}", audio_data_file).contains("File"));
 
         // Clone trait
         let cloned = audio_data.clone();
-        match cloned {
-            AudioData::Memory(vec) => assert_eq!(vec, data),
-            _ => panic!("Clone failed"),
-        }
+        let AudioData::Memory(vec) = cloned;
+        assert_eq!(vec, data);
     }
 
     #[test]
@@ -819,30 +683,14 @@ mod tests {
         };
 
         // bufferが適切に初期化されているか確認
-        match memory_state {
-            RecordingState::Memory {
-                buffer,
-                sample_rate,
-                channels,
-            } => {
-                assert_eq!(sample_rate, 48000);
-                assert_eq!(channels, 2);
-                assert!(buffer.lock().unwrap().is_empty());
-            }
-            _ => panic!("Expected Memory state"),
-        }
-
-        // ファイルモードの状態作成
-        let file_state = RecordingState::File {
-            path: PathBuf::from("/tmp/test.wav"),
-        };
-
-        match file_state {
-            RecordingState::File { path } => {
-                assert_eq!(path, PathBuf::from("/tmp/test.wav"));
-            }
-            _ => panic!("Expected File state"),
-        }
+        let RecordingState::Memory {
+            buffer,
+            sample_rate,
+            channels,
+        } = memory_state;
+        assert_eq!(sample_rate, 48000);
+        assert_eq!(channels, 2);
+        assert!(buffer.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -887,21 +735,6 @@ mod tests {
     }
 
     #[test]
-    fn test_start_recording_legacy_mode() {
-        // レガシーモードに設定
-        unsafe { std::env::set_var("LEGACY_TMP_WAV_FILE", "1") };
-
-        let backend = CpalAudioBackend::default();
-
-        // 録音開始前の状態確認
-        assert!(!backend.is_recording());
-        assert!(backend.recording_state.lock().unwrap().is_none());
-
-        // クリーンアップ
-        unsafe { std::env::remove_var("LEGACY_TMP_WAV_FILE") };
-    }
-
-    #[test]
     fn test_stop_recording_memory_mode() {
         // メモリモードでの動作をシミュレート
         let backend = CpalAudioBackend::default();
@@ -919,47 +752,13 @@ mod tests {
 
         // stop_recordingを実行
         let result = backend.stop_recording().unwrap();
+        let AudioData::Memory(wav_data) = result;
+        // WAVヘッダー（44バイト）+ データ（5サンプル * 2バイト = 10バイト）
+        assert_eq!(wav_data.len(), 54);
 
-        match result {
-            AudioData::Memory(wav_data) => {
-                // WAVヘッダー（44バイト）+ データ（5サンプル * 2バイト = 10バイト）
-                assert_eq!(wav_data.len(), 54);
-
-                // WAVヘッダーの基本チェック
-                assert_eq!(&wav_data[0..4], b"RIFF");
-                assert_eq!(&wav_data[8..12], b"WAVE");
-            }
-            _ => panic!("Expected AudioData::Memory"),
-        }
-
-        // 録音状態がクリアされていることを確認
-        assert!(!backend.is_recording());
-        assert!(backend.recording_state.lock().unwrap().is_none());
-    }
-
-    #[test]
-    fn test_stop_recording_file_mode() {
-        // ファイルモードでの動作をシミュレート
-        let backend = CpalAudioBackend::default();
-
-        // テスト用のRecordingState::Fileを設定
-        let test_path = PathBuf::from("/tmp/test.wav");
-        *backend.recording_state.lock().unwrap() = Some(RecordingState::File {
-            path: test_path.clone(),
-        });
-
-        // 録音フラグを設定
-        backend.recording.store(true, Ordering::SeqCst);
-
-        // stop_recordingを実行
-        let result = backend.stop_recording().unwrap();
-
-        match result {
-            AudioData::File(path) => {
-                assert_eq!(path, test_path);
-            }
-            _ => panic!("Expected AudioData::File"),
-        }
+        // WAVヘッダーの基本チェック
+        assert_eq!(&wav_data[0..4], b"RIFF");
+        assert_eq!(&wav_data[8..12], b"WAVE");
 
         // 録音状態がクリアされていることを確認
         assert!(!backend.is_recording());
@@ -1053,13 +852,9 @@ mod tests {
 
                 // 録音停止
                 let result = backend.stop_recording().unwrap();
-                match result {
-                    AudioData::Memory(data) => {
-                        println!("録音データサイズ: {} bytes", data.len());
-                        assert!(data.len() > 44); // 少なくともWAVヘッダーより大きい
-                    }
-                    _ => panic!("Expected Memory data"),
-                }
+                let AudioData::Memory(data) = result;
+                println!("録音データサイズ: {} bytes", data.len());
+                assert!(data.len() > 44); // 少なくともWAVヘッダーより大きい
             }
             Err(e) => {
                 println!("録音開始失敗（デバイスなし）: {}", e);

--- a/src/infrastructure/audio/mod.rs
+++ b/src/infrastructure/audio/mod.rs
@@ -9,9 +9,7 @@ pub trait AudioBackend {
     /// 録音を開始。
     fn start_recording(&self) -> Result<(), Box<dyn Error>>;
 
-    /// 録音を停止し、音声データを返します。
-    /// メモリモードの場合はWAVフォーマットのバイトデータ、
-    /// レガシーモードの場合はWAVファイルのパスを返します。
+    /// 録音を停止し、WAVフォーマットのバイトデータを返します。
     fn stop_recording(&self) -> Result<AudioData, Box<dyn Error>>;
 
     /// 現在録音中であれば `true`。

--- a/tests/performance_test.rs
+++ b/tests/performance_test.rs
@@ -229,9 +229,6 @@ async fn test_memory_usage() {
                         (size_mb / expected_mb) * 100.0
                     );
                 }
-                voice_input::infrastructure::audio::cpal_backend::AudioData::File(path) => {
-                    println!("📁 File mode - saved to: {:?}", path);
-                }
             }
         }
         Err(e) => {


### PR DESCRIPTION
## Summary
- drop file-based audio mode, keeping only in-memory recording
- simplify OpenAI client and recorder APIs accordingly
- update IPC structures for memory-only data
- adjust benchmarks, tests, and daemon code for new behavior

## Testing
- `cargo check`
- `cargo clippy --all-targets --features ci-test -- -D warnings`
- `cargo test --features ci-test` *(fails: linking with `cc` failed)*